### PR TITLE
Network Error Toast->Popup교체

### DIFF
--- a/GoodListener/GoodListener/Data/Network/API/Token/TokenAPI.swift
+++ b/GoodListener/GoodListener/Data/Network/API/Token/TokenAPI.swift
@@ -17,6 +17,9 @@ struct TokenAPI: Networkable {
             case .success(let model):
                 return completion(model, nil)
             case .failure(let error):
+                self.makePopup {
+                    requestAppleToken(request: request, completion: completion)
+                }
                 return completion(nil, error)
             }
         }

--- a/GoodListener/GoodListener/Data/Network/API/User/UserAPI.swift
+++ b/GoodListener/GoodListener/Data/Network/API/User/UserAPI.swift
@@ -19,6 +19,9 @@ struct UserAPI: Networkable {
             case .success(let model):
                 return completion(model, nil)
             case .failure(let error):
+                makePopup(action: {
+                    requestUserInfo(completion: completion)
+                })
                 return completion(nil, error)
             }
         })
@@ -33,6 +36,9 @@ struct UserAPI: Networkable {
             case .success(let model):
                 return completion(model, nil)
             case .failure(let error):
+                makePopup(action: {
+                    requestSignIn(request: request, completion: completion)
+                })
                 return completion(nil, error)
             }
         })
@@ -46,6 +52,9 @@ struct UserAPI: Networkable {
             case .success(_):
                 return completion((), nil)
             case .failure(let error):
+                makePopup(action: {
+                    reqeustDeleteAccount(completion: completion)
+                })
                 return completion(nil, error)
             }
         })
@@ -60,6 +69,9 @@ struct UserAPI: Networkable {
             case .success(let model):
                 return completion(model["isExist"].bool, nil)
             case .failure(let error):
+                makePopup(action: {
+                    requestNicknameCheck(request: request, completion: completion)
+                })
                 return completion(nil, error)
             }
         })
@@ -74,6 +86,9 @@ struct UserAPI: Networkable {
             case .success(let model):
                 return completion(model, nil)
             case .failure(let error):
+                makePopup(action: {
+                    updateUserInfo(request: request, completion: completion)
+                })
                 return completion(nil, error)
             }
         })
@@ -88,6 +103,9 @@ struct UserAPI: Networkable {
             case .success(let model):
                 return completion(model, nil)
             case .failure(let error):
+                makePopup(action: {
+                    updateDeviceToken(request: request, completion: completion)
+                })
                 return completion(nil, error)
             }
         })

--- a/GoodListener/GoodListener/Data/Network/Networkable.swift
+++ b/GoodListener/GoodListener/Data/Network/Networkable.swift
@@ -28,5 +28,27 @@ extension Networkable {
         LoadingIndicator.start()
         return MoyaProvider<Target>(plugins: [authPlugin])
     }
-
+    
+    static func makePopup(action: (()->Void)?) {
+        let popup = GLPopup()
+        popup.title = "네트워크 연결"
+        popup.contents = "네트워크에 접속할 수 없습니다.\n네트워크 연결상태를 확인해주세요."
+        popup.cancelIsHidden = false
+        popup.completeAction = action
+        popup.completeBtnTitle = "재시도"
+        
+        if let vc = UIApplication.getMostTopViewController() {
+            if let tab = vc.tabBarController {
+                tab.view.addSubview(popup)
+                popup.snp.makeConstraints {
+                    $0.edges.equalToSuperview()
+                }
+            } else if let navi = vc.navigationController {
+                navi.view.addSubview(popup)
+                popup.snp.makeConstraints {
+                    $0.edges.equalToSuperview()
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
### 작업내용
디자인팀과 이야기 후 토스트에서 팝업형태로 수정했습니다
![image](https://user-images.githubusercontent.com/59193640/191693320-0dd09545-f15e-41c7-b76c-1c93bec78d55.png)

### 적용방법
Networkable 프로토콜에 Extension으로 makePopup(action: ~) 함수가 구현돼 있습니다.
```Swift
static func updateUserInfo(request: (String, String, String), completion: @escaping (_ succeed: UserInfo?, _ failed: Error?) -> Void) {
        makeProvider().request(.userModify(request), completion: { result in
            switch ResponseData<UserInfo>.processModelResponse(result) {
            case .success(let model):
                return completion(model, nil)
            case .failure(let error):
                makePopup(action: {
                    updateUserInfo(request: request, completion: completion)
                })
                return completion(nil, error)
            }
        })
    }
```
이런식으로 Newtorkable 프로토콜을 채택해 구현한 함수에서 failure case에 makePopup 해주시고 completeAction으로 함수를 다시 실행해주시면 됩니다!