### PR TITLE
[App] Guest 기능 추가

### DIFF
--- a/GoodListener/GoodListener/Presentation/JoinScene/Join/View/JoinVC.swift
+++ b/GoodListener/GoodListener/Presentation/JoinScene/Join/View/JoinVC.swift
@@ -230,6 +230,25 @@ class JoinVC: UIViewController, SnapKitType, UITextViewDelegate {
             })
             .disposed(by: disposeBag)
         
+        output.guestMessage
+            .emit(onNext: { [weak self] message in
+                guard let self = self else { return }
+                
+                let popup = GLPopup()
+                popup.title = "알림"
+                popup.contents = message
+                popup.cancelIsHidden = true
+                popup.alignment = .center
+                
+                self.view.addSubview(popup)
+                popup.snp.makeConstraints {
+                    $0.edges.equalToSuperview()
+                }
+                
+                self.view.endEditing(true)
+            })
+            .disposed(by: disposeBag)
+        
     }
     
     //키보드 상단 완료 버튼

--- a/GoodListener/GoodListener/Presentation/JoinScene/Join/ViewModel/JoinViewModel.swift
+++ b/GoodListener/GoodListener/Presentation/JoinScene/Join/ViewModel/JoinViewModel.swift
@@ -23,15 +23,22 @@ class JoinViewModel: ViewModelType {
     struct Output {
         let okBtnResult: Signal<Bool>
         var poupMessage: Signal<String>
+        var guestMessage: Signal<String>
     }
     
     func transform(input: Input) -> Output {
         let okBtnResult = PublishRelay<Bool>()
         var popupMessage = PublishRelay<String>()
+        var guestMessage = PublishRelay<String>()
         
         input.okBtnTap
             .withLatestFrom(Observable.combineLatest(input.time, input.reason, input.moodImg))
             .subscribe(onNext: { [weak self] (time, reason, moodImg) in
+                if UserDefaultsManager.shared.isGuest {
+                    guestMessage.accept("로그인 후 이용해주세요")
+                    return
+                }
+                
                 if(time == [""] || reason == "" || moodImg == 0) {
                     popupMessage.accept("간략하게 입력해 주시면 \n리스너와 더 좋은 대화를 나눌 수 있어요!")
                 } else {
@@ -45,6 +52,8 @@ class JoinViewModel: ViewModelType {
                 }
             })
             .disposed(by: disposeBag)
-        return Output(okBtnResult: okBtnResult.asSignal(onErrorJustReturn: false), poupMessage: popupMessage.asSignal(onErrorJustReturn: ""))
+        return Output(okBtnResult: okBtnResult.asSignal(onErrorJustReturn: false),
+                      poupMessage: popupMessage.asSignal(onErrorJustReturn: ""),
+                      guestMessage: guestMessage.asSignal(onErrorJustReturn: ""))
     }
 }

--- a/GoodListener/GoodListener/Presentation/LoginScene/Login/View/LoginVC.swift
+++ b/GoodListener/GoodListener/Presentation/LoginScene/Login/View/LoginVC.swift
@@ -54,11 +54,9 @@ class LoginVC: UIViewController, SnapKitType {
         $0.layer.cornerRadius = 24
     }
     
-    let emailLoginBtn = GLButton().then{
-        $0.title = "이메일로 로그인"
-        $0.setImage(UIImage(named: "ic_login_email"), for: .normal)
+    let guestLoginBtn = GLButton().then{
+        $0.title = "게스트로 둘러보기"
         $0.contentHorizontalAlignment = .center
-        $0.imageEdgeInsets = .init(top: 0, left: 0, bottom: 0, right: 10) //<- 중요
     }
     
     let termsOfServiceBtn = UILabel().then {
@@ -110,7 +108,7 @@ class LoginVC: UIViewController, SnapKitType {
 
     func addComponents() {
         [titleLabel, subtitleLabel, buttonStackView, termsOfServiceBtn, termsOfServiceStackView].forEach { view.addSubview($0) }
-        [appleLoginBtn, emailLoginBtn].forEach { buttonStackView.addArrangedSubview($0) }
+        [appleLoginBtn, guestLoginBtn].forEach { buttonStackView.addArrangedSubview($0) }
         [termsOfService, termsOfService2, termsOfService3].forEach { termsOfServiceStackView.addArrangedSubview($0) }
     }
     
@@ -134,7 +132,7 @@ class LoginVC: UIViewController, SnapKitType {
             $0.height.equalTo(Const.glBtnHeight)
         }
         
-        emailLoginBtn.snp.makeConstraints {
+        guestLoginBtn.snp.makeConstraints {
             $0.height.equalTo(Const.glBtnHeight)
         }
         
@@ -151,7 +149,7 @@ class LoginVC: UIViewController, SnapKitType {
     
     func bind() {
         let output = viewModel.transform(input: LoginViewModel.Input(appleLoginBtnTap: appleLoginBtn.tapGesture,
-                                                                     nonLoginBtnTap: emailLoginBtn.tapGesture,
+                                                                     nonLoginBtnTap: guestLoginBtn.tapGesture,
                                                                      termsOfServiceBtnTap: termsOfServiceBtn.tapGesture))
         
         output.loginResult

--- a/GoodListener/GoodListener/Presentation/LoginScene/Login/ViewModel/LoginViewModel.swift
+++ b/GoodListener/GoodListener/Presentation/LoginScene/Login/ViewModel/LoginViewModel.swift
@@ -47,7 +47,16 @@ class LoginViewModel: NSObject, ViewModelType {
         input.nonLoginBtnTap
             .subscribe(onNext: { [weak self] _ in
                 guard let self = self else { return }
+                
                 loginResult.accept(true)
+                UserDefaultsManager.shared.isGuest = true
+                UserDefaultsManager.shared.nickname    = "Guest"
+                UserDefaultsManager.shared.age         = ""
+                UserDefaultsManager.shared.gender      = ""
+                UserDefaultsManager.shared.job         = ""
+                UserDefaultsManager.shared.profileImg  = 1
+                UserDefaultsManager.shared.description = "안녕하세요 굿 리스너입니다."
+                UserDefaultsManager.shared.userType    = "speaker"
             })
             .disposed(by: disposeBag)
         

--- a/GoodListener/GoodListener/Presentation/MainScene/Applicant/View/ApplicantVC.swift
+++ b/GoodListener/GoodListener/Presentation/MainScene/Applicant/View/ApplicantVC.swift
@@ -72,6 +72,7 @@ class ApplicantVC: UIViewController, SnapKitType {
         addComponents()
         setConstraints()
         bind()
+        addCallBtn()    // 전화 테스트용
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -186,6 +187,23 @@ class ApplicantVC: UIViewController, SnapKitType {
                 self.changeUI(self.applicantState)
             }
         }
+    }
+    
+    func addCallBtn() {
+        let button = GLButton()
+        button.title = "통화"
+        view.addSubview(button)
+        button.snp.makeConstraints {
+            $0.size.equalTo(50)
+            $0.right.equalToSuperview().inset(10)
+            $0.top.equalTo(navigationView.snp.bottom).offset(20)
+        }
+        
+        button.rx.tap
+            .bind(onNext: { [weak self] in
+                self?.coordinator?.call()
+            })
+            .disposed(by: disposeBag)
     }
 }
 

--- a/GoodListener/GoodListener/Presentation/MainScene/Flow/ApplicantCoordinator.swift
+++ b/GoodListener/GoodListener/Presentation/MainScene/Flow/ApplicantCoordinator.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 protocol ApplicantCoordinating: AnyObject {
-    
+    func call()
 }
 
 class ApplicantCoordinator: CoordinatorType {
@@ -32,6 +32,8 @@ class ApplicantCoordinator: CoordinatorType {
 }
 
 extension ApplicantCoordinator: ApplicantCoordinating {
-    
+    func call() {
+        parentCoordinator?.call()
+    }
 }
 

--- a/GoodListener/GoodListener/Presentation/MainScene/Flow/MainCoordinator.swift
+++ b/GoodListener/GoodListener/Presentation/MainScene/Flow/MainCoordinator.swift
@@ -34,7 +34,7 @@ class MainCoordinator: CoordinatorType {
     var tabBarController: CustomTabBarController
     
     // 유저 타입도 AppCoordinator에서 주입해줘야 합니다
-    var userType: UserType = .listener
+    var userType: UserType = .init(rawValue: UserDefaultsManager.shared.userType) ?? .speaker
     
     init(navigationController: UINavigationController) {
         self.navigationController = navigationController

--- a/GoodListener/GoodListener/Presentation/MainScene/Home/View/HomeVC.swift
+++ b/GoodListener/GoodListener/Presentation/MainScene/Home/View/HomeVC.swift
@@ -147,7 +147,6 @@ class HomeVC: UIViewController, SnapKitType {
         addComponents()
         setConstraints()
         bind()
-        addCallBtn()    // 전화 테스트용
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -424,22 +423,6 @@ class HomeVC: UIViewController, SnapKitType {
         containerView.layer.borderColor = .none
     }
     
-    func addCallBtn() {
-        let button = GLButton()
-        button.title = "통화"
-        view.addSubview(button)
-        button.snp.makeConstraints {
-            $0.size.equalTo(50)
-            $0.right.equalToSuperview().inset(10)
-            $0.top.equalTo(navigationView.snp.bottom).offset(20)
-        }
-        
-        button.rx.tap
-            .bind(onNext: { [weak self] in
-                self?.coordinator?.call()
-            })
-            .disposed(by: disposeBag)
-    }
     
     func fetchData(){
         initUI()

--- a/GoodListener/GoodListener/Presentation/MainScene/MyPage/MyPage/View/MyPageVC.swift
+++ b/GoodListener/GoodListener/Presentation/MainScene/MyPage/MyPage/View/MyPageVC.swift
@@ -82,6 +82,11 @@ class MyPageVC: UIViewController, SnapKitType {
         addComponents()
         setConstraints()
         bind()
+        if UserDefaultsManager.shared.isGuest {
+            tagView.collectionView.isHidden = true
+            editBtn.isHidden = true
+            profileImageEditView.isHidden = true
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/GoodListener/GoodListener/Presentation/MainScene/MyPage/MyPageSet/View/MyPageSetVC.swift
+++ b/GoodListener/GoodListener/Presentation/MainScene/MyPage/MyPageSet/View/MyPageSetVC.swift
@@ -222,6 +222,11 @@ class MyPageSetVC: UIViewController, SnapKitType {
     func bind() {
         logoutContainer.tapGesture
             .subscribe(onNext: { [weak self] _ in
+                if UserDefaultsManager.shared.isGuest {
+                    self?.coordinator?.logout()
+                    UserDefaultsManager.shared.logout()
+                }
+                
                 let popup = GLPopup()
                 popup.title = "알림"
                 popup.contents = PopupMessage.logout
@@ -238,6 +243,20 @@ class MyPageSetVC: UIViewController, SnapKitType {
         
         withdrawContainer.tapGesture
             .subscribe(onNext: { [weak self] _ in
+                if UserDefaultsManager.shared.isGuest {
+                    let popup = GLPopup()
+                    popup.title = "알림"
+                    popup.contents = "로그인 후 이용해주세요"
+                    popup.cancelIsHidden = true
+                    popup.alignment = .center
+                    
+                    self?.view.addSubview(popup)
+                    popup.snp.makeConstraints {
+                        $0.edges.equalToSuperview()
+                    }
+                    
+                    return
+                }
                 self?.coordinator?.moveToDeleteAccountPage()
             })
             .disposed(by: disposeBag)

--- a/GoodListener/GoodListener/Support/UserDefaultsManager.swift
+++ b/GoodListener/GoodListener/Support/UserDefaultsManager.swift
@@ -24,6 +24,7 @@ enum UserDefaultKey : String {
     // 로그인 관련 정보
     case appleID
     case isLogin
+    case isGuest
     
     // Push
     case pushCnt
@@ -59,6 +60,7 @@ class UserDefaultsManager {
         self.description = "안녕하세요 굿 리스너입니다."
         self.snsKind = ""
         self.profileImg = 0
+        self.isGuest = false
     }
     
     // MARK: - authtoken from rest
@@ -215,6 +217,19 @@ class UserDefaultsManager {
         
         set(isLogin) {
             UserDefaults.standard.set(isLogin, forKey:  UserDefaultKey.isLogin.rawValue)
+        }
+    }
+    
+    var isGuest : Bool {
+        get {
+            guard let isGuest = UserDefaults.standard.value(forKey: UserDefaultKey.isGuest.rawValue) as? Bool else {
+                return false
+            }
+            return isGuest
+        }
+        
+        set(isGuest) {
+            UserDefaults.standard.set(isGuest, forKey:  UserDefaultKey.isGuest.rawValue)
         }
     }
     


### PR DESCRIPTION
## 작업내용
- 게스트로 둘러보기 기능을 추가했습니다
- HomeVC에 있던 전화테스트버튼을 ApplicantVC로 이동했습니다.
- MainCoordinator에서 start전에 유저타입 설정했습니다.

## 전달사항
게스트로 로그인 시 UserdefaultsManager에 isGuest값이 true가 됩니다. 해당 값으로 분기처리하면 될것 같습니다.
기본적으로 게스트는 스피커이며, 현재 게스트 처리된곳은 아래 세가지입니다
1. 신청하기 -> 확인버튼 클릭 시 - 로그인 후 이용 팝업 출력
2. 마이페이지 - 닉네임 'Guest' 고정, 소개글 '안녕하세요 굿 리스너입니다' 고정, 프로필 수정버튼, 편집버튼, 태그 Hidden 처리
3. 마이페이지 설정 - 탈퇴하기 버튼 클릭 시 - 로그인 후 이용 팝업 출력
추가로 대화기록 에서 isGuest일때 리스트 안보여주는것만 처리되면 될 것 같습니당~